### PR TITLE
Add postgres-client-9.3 to Discourse Docker img packages

### DIFF
--- a/repos/discourse/opts.yml
+++ b/repos/discourse/opts.yml
@@ -59,6 +59,7 @@ packages:
     - jhead
     - ruby
     - git
+    - postgresql-client-9.3 # Discourse backups require pg_dump
 
 #
 


### PR DESCRIPTION
`pg_dump` is required for Discourse backups because :shrug:

/cc @envygeeks 